### PR TITLE
Add support for TLSv1.2

### DIFF
--- a/fir-client.ps1
+++ b/fir-client.ps1
@@ -70,6 +70,9 @@ Function IfPost {
 }
 
 Function Main {
+  #Support for TLSv1.2
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  
   #Display supplied arguments
   Write-Host "URL: $u"
   Write-Host "Endpoint: $ep"


### PR DESCRIPTION
Invoke-RestMethod, by default uses TLSv1.0. This adds support for TLSv1.2. I imagine the same could be done for TLSv.1.1, but this fixed my connection closed issue referenced here:

byt3smith#1

Thanks,
Wes
